### PR TITLE
fix: cargo doc compilation error

### DIFF
--- a/msfs/src/nvg.rs
+++ b/msfs/src/nvg.rs
@@ -227,7 +227,7 @@ impl Path {
     /// Angles are in radians.
     pub fn arc(&self, cx: f32, cy: f32, r: f32, a0: f32, a1: f32, dir: Direction) {
         unsafe {
-            sys::nvgArc(self.ctx, cx, cy, r, a0, a1, dir as i32);
+            sys::nvgArc(self.ctx, cx, cy, r, a0, a1, dir.to_sys() as _);
         }
     }
 
@@ -245,7 +245,7 @@ impl Path {
         dir: Direction,
     ) {
         unsafe {
-            sys::nvgEllipticalArc(self.ctx, cx, cy, rx, ry, a0, a1, dir as i32);
+            sys::nvgEllipticalArc(self.ctx, cx, cy, rx, ry, a0, a1, dir.to_sys() as _);
         }
     }
 
@@ -311,13 +311,21 @@ impl Path {
 }
 
 /// Winding direction
-#[derive(Debug)]
-#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
 pub enum Direction {
     /// Winding for holes.
-    Clockwise = sys::NVGwinding_NVG_CW,
+    Clockwise,
     /// Winding for solid shapes.
-    CounterClockwise = sys::NVGwinding_NVG_CCW,
+    CounterClockwise,
+}
+
+impl Direction {
+    fn to_sys(self) -> sys::NVGwinding {
+        match self {
+            Direction::Clockwise => sys::NVGwinding_NVG_CW,
+            Direction::CounterClockwise => sys::NVGwinding_NVG_CCW,
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Executing `cargo doc` resulted in the following compilation errors, whereas executing `cargo build --target wasm32-wasi` does not:
```
error[E0308]: mismatched types
   --> msfs\src\nvg.rs:319:17
    |
319 |     Clockwise = sys::NVGwinding_NVG_CW,
    |                 ^^^^^^^^^^^^^^^^^^^^^^ expected u32, found i32
error[E0308]: mismatched types
   --> msfs\src\nvg.rs:321:24
    |
321 |     CounterClockwise = sys::NVGwinding_NVG_CCW,
    |                        ^^^^^^^^^^^^^^^^^^^^^^^ expected u32, found i32
```

This PR fixes the issue by removing the `u32` `repr` and converting from the enum to an `i32`.