### PR TITLE
docs: hide gauge and mouse callback functions

### DIFF
--- a/msfs_derive/src/lib.rs
+++ b/msfs_derive/src/lib.rs
@@ -124,6 +124,7 @@ pub fn gauge(args: TokenStream, item: TokenStream) -> TokenStream {
             },
         };
 
+        #[doc(hidden)]
         #[no_mangle]
         pub extern "C" fn #extern_gauge_name(
             ctx: ::msfs::sys::FsContext,
@@ -135,6 +136,7 @@ pub fn gauge(args: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
 
+        #[doc(hidden)]
         #[no_mangle]
         pub extern "C" fn #extern_mouse_name(
             fx: std::os::raw::c_float,


### PR DESCRIPTION
When using `#[msfs::gauge(name=some_name)]` documentation for these functions ends up in the documentation generated by using `cargo doc`. This change removes these functions from generated documentation.