### PR TITLE
Fixed Sample by adding units to data definition structs

### DIFF
--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -6,9 +6,11 @@ use msfs::sim_connect::{
 #[derive(Debug)]
 struct Data {
     #[name = "RADIO HEIGHT"]
+    #[unit = "Feet"]
     #[epsilon = 0.01]
     height: f64,
     #[name = "AIRSPEED INDICATED"]
+    #[unit = "Knots"]
     #[epsilon = 0.01]
     airspeed: f64,
 }
@@ -17,20 +19,24 @@ struct Data {
 #[derive(Debug)]
 struct Controls {
     #[name = "ELEVATOR POSITION"]
+    #[unit = "Position"]
     elevator: f64,
     #[name = "AILERON POSITION"]
+    #[unit = "Position"]
     ailerons: f64,
     #[name = "RUDDER POSITION"]
+    #[unit = "Position"]
     rudder: f64,
     #[name = "ELEVATOR TRIM POSITION"]
+    #[unit = "Position"]
     elevator_trim: f64,
 }
 
 #[data_definition]
 #[derive(Debug)]
 struct Throttle(
-    #[name = "GENERAL ENG THROTTLE LEVER POSITION:1"] f64,
-    #[name = "GENERAL ENG THROTTLE LEVER POSITION:2"] f64,
+    #[name = "GENERAL ENG THROTTLE LEVER POSITION:1"] #[unit = "Percent"] f64,
+    #[name = "GENERAL ENG THROTTLE LEVER POSITION:2"] #[unit = "Percent"] f64,
 );
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Builds with `cargo build --target wasm32-wasi`.
Runs fine in MSFS.