### PR TITLE
chore: update bindgen

### DIFF
--- a/msfs/Cargo.toml
+++ b/msfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msfs"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["snek"]
 edition = "2018"
 description = "Rust bindings for the MSFS SDK"
@@ -11,6 +11,6 @@ msfs_derive = { path = "../msfs_derive", version = "0.2.0" }
 futures = "0.3"
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = "0.66"
 msfs_sdk = { path = "../msfs_sdk", version = "0.1.0" }
 cc = "1.0"

--- a/msfs/Cargo.toml
+++ b/msfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msfs"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["snek"]
 edition = "2018"
 description = "Rust bindings for the MSFS SDK"

--- a/msfs/build.rs
+++ b/msfs/build.rs
@@ -38,7 +38,7 @@ fn main() {
             .blocklist_function("nvgStrokePaint")
             .parse_callbacks(Box::new(bindgen::CargoCallbacks))
             .rustified_enum("SIMCONNECT_EXCEPTION")
-            .impl_debug(true);
+            .impl_debug(false);
 
         if wasm {
             bindings = bindings.clang_arg("-D_MSFS_WASM 1");

--- a/msfs/src/nvg.rs
+++ b/msfs/src/nvg.rs
@@ -328,7 +328,6 @@ impl Direction {
     }
 }
 
-#[derive(Debug)]
 #[doc(hidden)]
 pub enum PaintOrColor {
     Paint(Paint),
@@ -348,7 +347,7 @@ impl From<Color> for PaintOrColor {
 }
 
 /// The stroke and/or fill which will be applied to a path.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Style {
     stroke: Option<PaintOrColor>,
     fill: Option<PaintOrColor>,
@@ -369,7 +368,6 @@ impl Style {
 }
 
 /// Colors in NanoVG are stored as unsigned ints in ABGR format.
-#[derive(Debug)]
 pub struct Color(sys::NVGcolor);
 
 impl Color {
@@ -408,7 +406,6 @@ impl Color {
 
 /// NanoVG supports four types of paints: linear gradient, box gradient, radial gradient and image pattern.
 /// These can be used as paints for strokes and fills.
-#[derive(Debug)]
 pub struct Paint(sys::NVGpaint);
 
 impl Paint {


### PR DESCRIPTION
Clang 16 introduced a change which breaks old bindgen versions (https://github.com/rust-lang/rust-bindgen/issues/2312).
This PR upgrades bindgen to be future proof.