### PR TITLE
fix: remove allow unaligned references statement

### DIFF
--- a/msfs/src/sys.rs
+++ b/msfs/src/sys.rs
@@ -4,7 +4,6 @@
 #![allow(non_snake_case)]
 #![allow(dead_code)]
 #![allow(deref_nullptr)]
-#![allow(unaligned_references)]
 include!(concat!(env!("OUT_DIR"), "/msfs-sys.rs"));
 
 // https://github.com/rustwasm/team/issues/291


### PR DESCRIPTION
Fixes a warning introduces with #17.