### PR TITLE
feat: add flight functions

### DIFF
--- a/msfs/src/sim_connect.rs
+++ b/msfs/src/sim_connect.rs
@@ -563,8 +563,8 @@ impl<'a> SimConnect<'a> {
             map_err(sys::SimConnect_FlightSave(
                 self.handle,
                 flight_file_path.as_ptr(),
-                title.map(|x| x.as_ptr()).unwrap_or(std::ptr::null()),
-                description.map(|x| x.as_ptr()).unwrap_or(std::ptr::null()),
+                title.as_ref().map(|x| x.as_ptr()).unwrap_or(std::ptr::null()),
+                description.as_ref().map(|x| x.as_ptr()).unwrap_or(std::ptr::null()),
                 0,
             ))?;
         }

--- a/msfs/src/sim_connect.rs
+++ b/msfs/src/sim_connect.rs
@@ -511,6 +511,55 @@ impl<'a> SimConnect<'a> {
         }
         Ok(())
     }
+
+    /// Load a .FLT file from disk
+    pub fn load_flight(&mut self, flight_file_path: &str) -> Result<()> {
+        let flight_file_path = std::ffi::CString::new(flight_file_path).unwrap();
+
+        unsafe {
+            map_err(sys::SimConnect_FlightLoad(
+                self.handle,
+                flight_file_path.as_ptr(),
+            ))?;
+        }
+        Ok(())
+    }
+
+    /// Save the current sim state to a .FLT file
+    pub fn save_flight(
+        &mut self,
+        flight_file_path: &str,
+        title: Option<&str>,
+        description: Option<&str>,
+    ) -> Result<()> {
+        let flight_file_path = std::ffi::CString::new(flight_file_path).unwrap();
+        let title = title.map(|x| std::ffi::CString::new(x).unwrap());
+        let description = description.map(|x| std::ffi::CString::new(x).unwrap());
+
+        unsafe {
+            map_err(sys::SimConnect_FlightSave(
+                self.handle,
+                flight_file_path.as_ptr(),
+                title.map(|x| x.as_ptr()).unwrap_or(std::ptr::null()),
+                description.map(|x| x.as_ptr()).unwrap_or(std::ptr::null()),
+                0,
+            ))?;
+        }
+        Ok(())
+    }
+
+    /// Load a .PLN file from disk
+    pub fn load_flight_plan(&mut self, flight_plan_file_path: &str) -> Result<()> {
+        let flight_plan_file_path = std::ffi::CString::new(flight_plan_file_path).unwrap();
+
+        unsafe {
+            map_err(sys::SimConnect_FlightPlanLoad(
+                self.handle,
+                flight_plan_file_path.as_ptr(),
+            ))?;
+        }
+        Ok(())
+    }
 }
 
 impl<'a> Drop for SimConnect<'a> {

--- a/msfs/src/sim_connect.rs
+++ b/msfs/src/sim_connect.rs
@@ -563,8 +563,14 @@ impl<'a> SimConnect<'a> {
             map_err(sys::SimConnect_FlightSave(
                 self.handle,
                 flight_file_path.as_ptr(),
-                title.as_ref().map(|x| x.as_ptr()).unwrap_or(std::ptr::null()),
-                description.as_ref().map(|x| x.as_ptr()).unwrap_or(std::ptr::null()),
+                title
+                    .as_ref()
+                    .map(|x| x.as_ptr())
+                    .unwrap_or(std::ptr::null()),
+                description
+                    .as_ref()
+                    .map(|x| x.as_ptr())
+                    .unwrap_or(std::ptr::null()),
                 0,
             ))?;
         }


### PR DESCRIPTION
This adds three functions: 
- `load_flight` - `SimConnect_FlightLoad`
- `save_flight` - `SimConnect_FlightSave`
- `load_flight_plan` - `SimConnect_FlightPlanLoad`

The functions are documented here https://docs.flightsimulator.com/html/Programming_Tools/SimConnect/SimConnect_API_Reference.htm#:~:text=AI%20controlled%20aircraft.-,Flights,-Function