### PR TITLE
fix: fsNetworkHttpRequestPost now allocates pointer correctly

### DIFF
--- a/msfs/src/network.rs
+++ b/msfs/src/network.rs
@@ -2,8 +2,7 @@
 
 use crate::sys;
 use std::{
-    ffi::{self, CStr, CString},
-    ptr, slice,
+    ffi::{self, CStr, CString}, ptr, slice
 };
 
 type NetworkCallback = Box<dyn FnOnce(NetworkRequest, i32)>;
@@ -73,7 +72,8 @@ impl<'a> NetworkRequestBuilder<'a> {
     ) -> Option<NetworkRequest> {
         // SAFETY: we need a *mut i8 for the FsNetworkHttpRequestParam struct but this should be fine.
         let raw_post_field =
-            post_field.map_or(ptr::null_mut(), |f| f.as_c_str().as_ptr() as *mut i8);
+            post_field.map_or(ptr::null_mut(), |f| f.into_raw());
+
         // SAFETY: Because the struct in the C code is not defined as const char* we need to cast
         // the *const into *mut which should be safe because the function should not change it anyway
         let mut headers = self
@@ -101,6 +101,10 @@ impl<'a> NetworkRequestBuilder<'a> {
                 callback_data,
             )
         };
+
+        // This frees the memory of the string pointer, do NOT remove this
+        let _ = unsafe { CString::from_raw(raw_post_field) };
+
         if request_id == 0 {
             // Free the callback
             let _: Box<NetworkCallback> = unsafe { Box::from_raw(callback_data as *mut _) };


### PR DESCRIPTION
We were running into an issue where we were trying to send some post requests to sentry and the pointer would not resolve correctly. This PR fixes the pointer allocation so the post requests will actually contain the data