### PR TITLE
fix: added clang std argument

### DIFF
--- a/msfs/build.rs
+++ b/msfs/build.rs
@@ -30,6 +30,7 @@ fn main() {
             .clang_arg("-fms-extensions")
             .clang_arg("-fvisibility=default")
             .clang_arg("-xc++")
+            .clang_arg("-std=c++17")
             .clang_arg("-v")
             .header("src/bindgen_support/wrapper.h")
             .blocklist_function("nvgFillColor")


### PR DESCRIPTION
Fix: #34 

This PR adds the argument `-std=c++17` in `clang` call. This is because by default `clang` may be running with different std and fail the compilation.