### PR TITLE
feat: bindgen fix and update

### DIFF
--- a/msfs/Cargo.toml
+++ b/msfs/Cargo.toml
@@ -12,6 +12,6 @@ futures = "0.3"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = "0.72"
 msfs_sdk = { path = "../msfs_sdk", version = "0.1.0" }
 cc = "1.0"

--- a/msfs/build.rs
+++ b/msfs/build.rs
@@ -39,7 +39,17 @@ fn main() {
             .blocklist_function("nvgStrokePaint")
             .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
             .rustified_enum("SIMCONNECT_EXCEPTION")
-            .impl_debug(false);
+            .impl_debug(false)
+            // `opaque_type` added to avoid alignmnet errors. Theese alignment errors are caused
+            // because virutal methods are not well supported in rust-bindgen.
+            .opaque_type("IGaugeCDrawableCreateParameters")
+            .opaque_type("IGaugeCDrawableDrawParameters")
+            .opaque_type("IGaugeCDrawable")
+            .opaque_type("IGaugeCCallback")
+            .opaque_type("ISerializableGaugeCCallback")
+            .opaque_type("IAircraftCCallback")
+            .opaque_type("IPanelCCallback")
+            .opaque_type("IFSXPanelCCallback");
 
         if wasm {
             bindings = bindings.clang_arg("-D_MSFS_WASM 1");


### PR DESCRIPTION
This PR does the following changes:
- update of `bindgen` to `0.72`
- addition of `opaque_type` in bindgen flags to work around alignment issues with virtual methods in MSFS SDK. This allows `cargo test` to run successfully.

NOTE: with the update of bindgen from `0.69` to `0.72`, the size and alignment checks have been moved from unit tests to checks at compilation time. Without adding `opaque_type`, bindgen 0.69 failed tests, while bindgen 0.72 fails compilation.
